### PR TITLE
Update the THREE.js references to point to cdn version

### DIFF
--- a/GUTCP_FDTD.html
+++ b/GUTCP_FDTD.html
@@ -19,14 +19,13 @@
             <br>Physics by : <a href="mailto:rmills@brilliantlightpower.com"
             >Dr Randell L Mills</a> - FDTD Simulation by : <a href="mailto:vacamiguel@gmail.com">J Miguel Vaca</a> 
         </div>
-
-		<script src="https://threejs.org/build/three.js"></script>
-		<script src="https://mrdoob.github.io/three.js/examples/js/WebGL.js"></script>
+		<script src="https://unpkg.com/three@0.142.0/build/three.js"></script>
+		<script src="./dat.gui.min.js"></script>
+		<script src="https://unpkg.com/three@0.142.0/examples/js/controls/OrbitControls.js"></script>
+		<script src="https://unpkg.com/three@0.135.0/examples/js/WebGL.js"></script>
 		<!--script src="https://threejs.org/examples/js/Detector.js"></script-->
-		<script src="https://threejs.org/examples/js/libs/stats.min.js"></script>
-		<script src="https://threejs.org/examples/js/libs/dat.gui.min.js"></script>
-		<script src="https://threejs.org/examples/js/controls/OrbitControls.js"></script>
-		<script src="https://threejs.org/examples/js/GPUComputationRenderer.js"></script>
+		<script src="https://unpkg.com/three@0.142.0/examples/js/libs/stats.min.js"></script>
+		<script src="https://unpkg.com/three@0.142.0/examples/js/misc/GPUComputationRenderer.js"></script>
 		<script src="gutcp.js"></script>
 
 		<!--script src="../three.js/build/three.js"></script-->
@@ -366,7 +365,7 @@
 
 				initComputeRenderer() {
 			
-					this.gpuCompute = new GPUComputationRenderer( this.xDim*this.yDim, this.zDim, this.renderer );
+					this.gpuCompute = new THREE.GPUComputationRenderer( this.xDim*this.yDim, this.zDim, this.renderer );
 
 					this.textureElectric = this.gpuCompute.createTexture();
 					this.textureMagnetic = this.gpuCompute.createTexture();
@@ -492,7 +491,7 @@
 		</script>
 		
 		<script>
-			if ( WEBGL.isWebGLAvailable() ) {
+			if ( THREE.WEBGL.isWebGLAvailable() ) {
 				var container, stats;
 				var camera, scene, renderer, geometry, controls, fdtd;
 				var clock = new THREE.Clock();
@@ -509,7 +508,7 @@
 				init();
 				animate();
 			} else {
-				var warning = WEBGL.getWebGLErrorMessage();
+				var warning = THREE.WEBGL.getWebGLErrorMessage();
 				document.getElementById('container').appendChild(warning);
 			}
 
@@ -585,7 +584,7 @@
 
 			function getCameraConstant( camera ) {
 
-				return window.innerHeight / ( Math.tan( THREE.Math.DEG2RAD * 0.5 * camera.fov ) / camera.zoom );
+				return window.innerHeight / ( Math.tan( THREE.MathUtils.DEG2RAD * 0.5 * camera.fov ) / camera.zoom );
 			}
 
 			function animate() {

--- a/GUTCP_Neutrino.html
+++ b/GUTCP_Neutrino.html
@@ -22,9 +22,9 @@
             <br>Physics by : <a href="mailto:rmills@brilliantlightpower.com">Dr Randell L Mills</a> - Visualisation by : <a href="mailto:vacamiguel@gmail.com">J Miguel Vaca</a> 
         </div>
 
-		<script src="https://threejs.org/build/three.js"></script>
+		<script src="https://unpkg.com/three@0.142.0/build/three.js"></script>
 		<script src="./dat.gui.min.js"></script>
-		<script src="https://threejs.org/examples/js/controls/OrbitControls.js"></script>
+		<script src="https://unpkg.com/three@0.142.0/examples/js/controls/OrbitControls.js"></script>
 		<script src="./gutcp.js"></script>
 
 		<script>
@@ -158,7 +158,7 @@
 			}
 
 			function getCameraConstant( camera ) {
-				return window.innerHeight / ( Math.tan( THREE.Math.DEG2RAD * 0.5 * camera.fov ) / camera.zoom );
+				return window.innerHeight / ( Math.tan( THREE.MathUtils.DEG2RAD * 0.5 * camera.fov ) / camera.zoom );
 			}
 
 			function initGUI() {

--- a/GUTCP_Nucleon.html
+++ b/GUTCP_Nucleon.html
@@ -17,9 +17,9 @@
             <br>Physics by : <a href="mailto:rmills@brilliantlightpower.com">Dr Randell L Mills</a> - Visualisation by : <a href="mailto:vacamiguel@gmail.com">J Miguel Vaca</a> 
         </div>
 
-		<script src="https://threejs.org/build/three.js"></script>
+		<script src="https://unpkg.com/three@0.142.0/build/three.js"></script>
 		<script src="./dat.gui.min.js"></script>
-		<script src="https://threejs.org/examples/js/controls/OrbitControls.js"></script>
+		<script src="https://unpkg.com/three@0.142.0/examples/js/controls/OrbitControls.js"></script>
 		<script src="./gutcp.js"></script>
 
 		<script>
@@ -125,7 +125,7 @@
 			}
 
 			function getCameraConstant( camera ) {
-				return window.innerHeight / ( Math.tan( THREE.Math.DEG2RAD * 0.5 * camera.fov ) / camera.zoom );
+				return window.innerHeight / ( Math.tan( THREE.MathUtils.DEG2RAD * 0.5 * camera.fov ) / camera.zoom );
 			}
 
 			function initGUI() {

--- a/GUTCP_Orbitsphere.html
+++ b/GUTCP_Orbitsphere.html
@@ -17,9 +17,9 @@
             <br>Physics by : <a href="mailto:rmills@brilliantlightpower.com">Dr Randell L Mills</a> - Visualisation by : <a href="mailto:vacamiguel@gmail.com">J Miguel Vaca</a> 
         </div>
 
-		<script src="https://threejs.org/build/three.js"></script>
+		<script src="https://unpkg.com/three@0.142.0/build/three.js"></script>
 		<script src="./dat.gui.min.js"></script>
-		<script src="https://threejs.org/examples/js/controls/OrbitControls.js"></script>
+		<script src="https://unpkg.com/three@0.142.0/examples/js/controls/OrbitControls.js"></script>
 		<script src="./gutcp.js"></script>
 
 		<script>

--- a/GUTCP_Photon.html
+++ b/GUTCP_Photon.html
@@ -22,9 +22,9 @@
             <br>Physics by : <a href="mailto:rmills@brilliantlightpower.com">Dr Randell L Mills</a> - Visualisation by : <a href="mailto:vacamiguel@gmail.com">J Miguel Vaca</a> 
         </div>
 
-		<script src="https://threejs.org/build/three.js"></script>
+		<script src="https://unpkg.com/three@0.142.0/build/three.js"></script>
 		<script src="./dat.gui.min.js"></script>
-		<script src="https://threejs.org/examples/js/controls/OrbitControls.js"></script>
+		<script src="https://unpkg.com/three@0.142.0/examples/js/controls/OrbitControls.js"></script>
 		<script src="./gutcp.js"></script>
 
 		<script>
@@ -154,7 +154,7 @@
 			}
 
 			function getCameraConstant( camera ) {
-				return window.innerHeight / ( Math.tan( THREE.Math.DEG2RAD * 0.5 * camera.fov ) / camera.zoom );
+				return window.innerHeight / ( Math.tan( THREE.MathUtils.DEG2RAD * 0.5 * camera.fov ) / camera.zoom );
 			}
 
 			function initGUI() {

--- a/GUTCP_PhotonAbsorptionByFreeElectron.html
+++ b/GUTCP_PhotonAbsorptionByFreeElectron.html
@@ -11,9 +11,8 @@
 </head>
 <body>
 
-    <script src="https://threejs.org/build/three.js"></script>
-    <!--script src="https://threejs.org/examples/js/libs/dat.gui.min.js"></script-->
-    <script src="https://threejs.org/examples/js/controls/OrbitControls.js"></script>
+    <script src="https://unpkg.com/three@0.142.0/build/three.js"></script>
+    <script src="https://unpkg.com/three@0.142.0/examples/js/controls/OrbitControls.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/mathjs/7.5.1/math.min.js"></script>
 
     <!--  -->
@@ -1838,7 +1837,7 @@
         }
 
         function getCameraConstant( camera ) {
-            return window.innerHeight / ( Math.tan( THREE.Math.DEG2RAD * 0.5 * camera.fov ) / camera.zoom );
+            return window.innerHeight / ( Math.tan( THREE.MathUtils.DEG2RAD * 0.5 * camera.fov ) / camera.zoom );
         }
 
         function setTime( time ) {

--- a/GUTCP_PhotonAbsorptionByFreeElectron10.html
+++ b/GUTCP_PhotonAbsorptionByFreeElectron10.html
@@ -11,9 +11,9 @@
 </head>
 <body>
 
-    <script src="https://threejs.org/build/three.js"></script>
-    <script src="https://threejs.org/examples/js/libs/dat.gui.min.js"></script>
-    <script src="https://threejs.org/examples/js/controls/OrbitControls.js"></script>
+    <script src="https://unpkg.com/three@0.142.0/build/three.js"></script>
+    <script src="./dat.gui.min.js"></script>
+    <script src="https://unpkg.com/three@0.142.0/examples/js/controls/OrbitControls.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/mathjs/7.5.1/math.min.js"></script>
 
     <script type="x-shader/x-vertex" id="basicShader">
@@ -1618,7 +1618,7 @@
         }
 
         function getCameraConstant( camera ) {
-            return window.innerHeight / ( Math.tan( THREE.Math.DEG2RAD * 0.5 * camera.fov ) / camera.zoom );
+            return window.innerHeight / ( Math.tan( THREE.MathUtils.DEG2RAD * 0.5 * camera.fov ) / camera.zoom );
         }
 
        function setTime( time ) {

--- a/GUTCP_PhotonAbsorptionByFreeElectron11.html
+++ b/GUTCP_PhotonAbsorptionByFreeElectron11.html
@@ -11,9 +11,9 @@
 </head>
 <body>
 
-    <script src="https://threejs.org/build/three.js"></script>
-    <script src="https://threejs.org/examples/js/libs/dat.gui.min.js"></script>
-    <script src="https://threejs.org/examples/js/controls/OrbitControls.js"></script>
+    <script src="https://unpkg.com/three@0.142.0/build/three.js"></script>
+    <script src="./dat.gui.min.js"></script>
+    <script src="https://unpkg.com/three@0.142.0/examples/js/controls/OrbitControls.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/mathjs/7.5.1/math.min.js"></script>
 
     <script type="x-shader/x-vertex" id="basicShader">
@@ -1733,7 +1733,7 @@
         }
 
         function getCameraConstant( camera ) {
-            return window.innerHeight / ( Math.tan( THREE.Math.DEG2RAD * 0.5 * camera.fov ) / camera.zoom );
+            return window.innerHeight / ( Math.tan( THREE.MathUtils.DEG2RAD * 0.5 * camera.fov ) / camera.zoom );
         }
 
        function setTime( time ) {

--- a/GUTCP_PhotonAbsorptionByFreeElectron12.html
+++ b/GUTCP_PhotonAbsorptionByFreeElectron12.html
@@ -11,9 +11,9 @@
 </head>
 <body>
 
-    <script src="https://threejs.org/build/three.js"></script>
-    <script src="https://threejs.org/examples/js/libs/dat.gui.min.js"></script>
-    <script src="https://threejs.org/examples/js/controls/OrbitControls.js"></script>
+    <script src="https://unpkg.com/three@0.142.0/build/three.js"></script>
+    <script src="./dat.gui.min.js"></script>
+    <script src="https://unpkg.com/three@0.142.0/examples/js/controls/OrbitControls.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/mathjs/7.5.1/math.min.js"></script>
 
     <!--  -->
@@ -1795,7 +1795,7 @@
         }
 
         function getCameraConstant( camera ) {
-            return window.innerHeight / ( Math.tan( THREE.Math.DEG2RAD * 0.5 * camera.fov ) / camera.zoom );
+            return window.innerHeight / ( Math.tan( THREE.MathUtils.DEG2RAD * 0.5 * camera.fov ) / camera.zoom );
         }
 
         function setTime( time ) {

--- a/GUTCP_PhotonAbsorptionByFreeElectron4.html
+++ b/GUTCP_PhotonAbsorptionByFreeElectron4.html
@@ -17,9 +17,9 @@
     </div>
     -->
 
-    <script src="https://threejs.org/build/three.js"></script>
-    <script src="https://threejs.org/examples/js/libs/dat.gui.min.js"></script>
-    <script src="https://threejs.org/examples/js/controls/OrbitControls.js"></script>
+    <script src="https://unpkg.com/three@0.142.0/build/three.js"></script>
+    <script src="./dat.gui.min.js"></script>
+    <script src="https://unpkg.com/three@0.142.0/examples/js/controls/OrbitControls.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/mathjs/7.5.1/math.min.js"></script>
 
     <script type="x-shader/x-vertex" id="vertexShader">
@@ -579,7 +579,7 @@
         }
 
         function getCameraConstant( camera ) {
-            return window.innerHeight / ( Math.tan( THREE.Math.DEG2RAD * 0.5 * camera.fov ) / camera.zoom );
+            return window.innerHeight / ( Math.tan( THREE.MathUtils.DEG2RAD * 0.5 * camera.fov ) / camera.zoom );
         }
             
         function animate() {

--- a/GUTCP_PhotonAbsorptionByFreeElectron5.html
+++ b/GUTCP_PhotonAbsorptionByFreeElectron5.html
@@ -17,9 +17,9 @@
     </div>
     -->
 
-    <script src="https://threejs.org/build/three.js"></script>
-    <script src="https://threejs.org/examples/js/libs/dat.gui.min.js"></script>
-    <script src="https://threejs.org/examples/js/controls/OrbitControls.js"></script>
+    <script src="https://unpkg.com/three@0.142.0/build/three.js"></script>
+    <script src="./dat.gui.min.js"></script>
+    <script src="https://unpkg.com/three@0.142.0/examples/js/controls/OrbitControls.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/mathjs/7.5.1/math.min.js"></script>
 
     <script type="x-shader/x-vertex" id="vertexShader">
@@ -623,7 +623,7 @@
         }
 
         function getCameraConstant( camera ) {
-            return window.innerHeight / ( Math.tan( THREE.Math.DEG2RAD * 0.5 * camera.fov ) / camera.zoom );
+            return window.innerHeight / ( Math.tan( THREE.MathUtils.DEG2RAD * 0.5 * camera.fov ) / camera.zoom );
         }
             
         function animate() {

--- a/GUTCP_PhotonAbsorptionByFreeElectron6.html
+++ b/GUTCP_PhotonAbsorptionByFreeElectron6.html
@@ -17,9 +17,9 @@
     </div>
     -->
 
-    <script src="https://threejs.org/build/three.js"></script>
-    <script src="https://threejs.org/examples/js/libs/dat.gui.min.js"></script>
-    <script src="https://threejs.org/examples/js/controls/OrbitControls.js"></script>
+    <script src="https://unpkg.com/three@0.142.0/build/three.js"></script>
+    <script src="./dat.gui.min.js"></script>
+    <script src="https://unpkg.com/three@0.142.0/examples/js/controls/OrbitControls.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/mathjs/7.5.1/math.min.js"></script>
 
     <script type="x-shader/x-vertex" id="vertexShader">
@@ -628,7 +628,7 @@
         }
 
         function getCameraConstant( camera ) {
-            return window.innerHeight / ( Math.tan( THREE.Math.DEG2RAD * 0.5 * camera.fov ) / camera.zoom );
+            return window.innerHeight / ( Math.tan( THREE.MathUtils.DEG2RAD * 0.5 * camera.fov ) / camera.zoom );
         }
             
         function animate() {

--- a/GUTCP_PhotonAbsorptionByFreeElectron7.html
+++ b/GUTCP_PhotonAbsorptionByFreeElectron7.html
@@ -17,9 +17,9 @@
     </div>
     -->
 
-    <script src="https://threejs.org/build/three.js"></script>
-    <script src="https://threejs.org/examples/js/libs/dat.gui.min.js"></script>
-    <script src="https://threejs.org/examples/js/controls/OrbitControls.js"></script>
+    <script src="https://unpkg.com/three@0.142.0/build/three.js"></script>
+    <script src="./dat.gui.min.js"></script>
+    <script src="https://unpkg.com/three@0.142.0/examples/js/controls/OrbitControls.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/mathjs/7.5.1/math.min.js"></script>
 
     <script type="x-shader/x-vertex" id="vertexShader">
@@ -749,7 +749,7 @@
         }
 
         function getCameraConstant( camera ) {
-            return window.innerHeight / ( Math.tan( THREE.Math.DEG2RAD * 0.5 * camera.fov ) / camera.zoom );
+            return window.innerHeight / ( Math.tan( THREE.MathUtils.DEG2RAD * 0.5 * camera.fov ) / camera.zoom );
         }
             
         function animate() {

--- a/GUTCP_PhotonAbsorptionByFreeElectron8.html
+++ b/GUTCP_PhotonAbsorptionByFreeElectron8.html
@@ -17,9 +17,9 @@
     </div>
     -->
 
-    <script src="https://threejs.org/build/three.js"></script>
-    <script src="https://threejs.org/examples/js/libs/dat.gui.min.js"></script>
-    <script src="https://threejs.org/examples/js/controls/OrbitControls.js"></script>
+    <script src="https://unpkg.com/three@0.142.0/build/three.js"></script>
+    <script src="./dat.gui.min.js"></script>
+    <script src="https://unpkg.com/three@0.142.0/examples/js/controls/OrbitControls.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/mathjs/7.5.1/math.min.js"></script>
 
     <script type="x-shader/x-vertex" id="vertexShader">
@@ -614,7 +614,7 @@
         }
 
         function getCameraConstant( camera ) {
-            return window.innerHeight / ( Math.tan( THREE.Math.DEG2RAD * 0.5 * camera.fov ) / camera.zoom );
+            return window.innerHeight / ( Math.tan( THREE.MathUtils.DEG2RAD * 0.5 * camera.fov ) / camera.zoom );
         }
             
         function animate() {

--- a/GUTCP_PhotonAbsorptionByFreeElectron9.html
+++ b/GUTCP_PhotonAbsorptionByFreeElectron9.html
@@ -17,9 +17,9 @@
     </div>
     -->
 
-    <script src="https://threejs.org/build/three.js"></script>
-    <script src="https://threejs.org/examples/js/libs/dat.gui.min.js"></script>
-    <script src="https://threejs.org/examples/js/controls/OrbitControls.js"></script>
+    <script src="https://unpkg.com/three@0.142.0/build/three.js"></script>
+    <script src="./dat.gui.min.js"></script>
+    <script src="https://unpkg.com/three@0.142.0/examples/js/controls/OrbitControls.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/mathjs/7.5.1/math.min.js"></script>
 
     <script type="x-shader/x-vertex" id="basicShader">
@@ -1598,7 +1598,7 @@
         }
 
         function getCameraConstant( camera ) {
-            return window.innerHeight / ( Math.tan( THREE.Math.DEG2RAD * 0.5 * camera.fov ) / camera.zoom );
+            return window.innerHeight / ( Math.tan( THREE.MathUtils.DEG2RAD * 0.5 * camera.fov ) / camera.zoom );
         }
             
         function animate() {

--- a/GUTCP_PhotonAbsorptionEmission.html
+++ b/GUTCP_PhotonAbsorptionEmission.html
@@ -16,10 +16,10 @@
 		</style>
 	</head>
 	<body>
-		<script src="https://threejs.org/build/three.js"></script>
-		<script src="https://threejs.org/examples/js/libs/dat.gui.min.js"></script>
-		<script src="https://threejs.org/examples/js/controls/OrbitControls.js"></script>
-		<script src="./gutcp.js"></script>
+		<script src="https://unpkg.com/three@0.142.0/build/three.js"></script>
+    <script src="./dat.gui.min.js"></script>
+    <script src="https://unpkg.com/three@0.142.0/examples/js/controls/OrbitControls.js"></script>
+    <script src="./gutcp.js"></script>
 
 		<script>
 
@@ -197,7 +197,7 @@
 			}
 
 			function getCameraConstant( camera ) {
-				return window.innerHeight / ( Math.tan( THREE.Math.DEG2RAD * 0.5 * camera.fov ) / camera.zoom );
+				return window.innerHeight / ( Math.tan( THREE.MathUtils.DEG2RAD * 0.5 * camera.fov ) / camera.zoom );
 			}
 			
 			function initGUI() {

--- a/GUTCP_PhotonAbsorptionEmission2.html
+++ b/GUTCP_PhotonAbsorptionEmission2.html
@@ -16,10 +16,10 @@
 		</style>
 	</head>
 	<body>
-		<script src="https://threejs.org/build/three.js"></script>
-		<script src="https://threejs.org/examples/js/libs/dat.gui.min.js"></script>
-		<script src="https://threejs.org/examples/js/controls/OrbitControls.js"></script>
-		<script src="./gutcp.js"></script>
+		<script src="https://unpkg.com/three@0.142.0/build/three.js"></script>
+    <script src="./dat.gui.min.js"></script>
+    <script src="https://unpkg.com/three@0.142.0/examples/js/controls/OrbitControls.js"></script>
+    <script src="./gutcp.js"></script>
 
 		<script>
 
@@ -201,7 +201,7 @@
 			}
 
 			function getCameraConstant( camera ) {
-				return window.innerHeight / ( Math.tan( THREE.Math.DEG2RAD * 0.5 * camera.fov ) / camera.zoom );
+				return window.innerHeight / ( Math.tan( THREE.MathUtils.DEG2RAD * 0.5 * camera.fov ) / camera.zoom );
 			}
 			
 			function initGUI() {

--- a/GUTCP_PhotonElectron.html
+++ b/GUTCP_PhotonElectron.html
@@ -22,10 +22,10 @@
             <br>Physics by : <a href="mailto:rmills@brilliantlightpower.com">Dr Randell L Mills</a> - Visualisation by : <a href="mailto:vacamiguel@gmail.com">J Miguel Vaca</a> 
         </div>
 
-		<script src="https://threejs.org/build/three.js"></script>
-		<script src="./dat.gui.min.js"></script>
-		<script src="https://threejs.org/examples/js/controls/OrbitControls.js"></script>
-		<script src="./gutcp.js"></script>
+		<script src="https://unpkg.com/three@0.142.0/build/three.js"></script>
+    <script src="./dat.gui.min.js"></script>
+    <script src="https://unpkg.com/three@0.142.0/examples/js/controls/OrbitControls.js"></script>
+    <script src="./gutcp.js"></script>
 
 		<script>
 
@@ -170,7 +170,7 @@
 			}
 
 			function getCameraConstant( camera ) {
-				return window.innerHeight / ( Math.tan( THREE.Math.DEG2RAD * 0.5 * camera.fov ) / camera.zoom );
+				return window.innerHeight / ( Math.tan( THREE.MathUtils.DEG2RAD * 0.5 * camera.fov ) / camera.zoom );
 			}
 
 			function initGUI() {

--- a/GUTCP_PhotonNew.html
+++ b/GUTCP_PhotonNew.html
@@ -22,10 +22,10 @@
             <br>Physics by : <a href="mailto:rmills@brilliantlightpower.com">Dr Randell L Mills</a> - Visualisation by : <a href="mailto:vacamiguel@gmail.com">J Miguel Vaca</a> 
         </div>
 
-		<script src="https://threejs.org/build/three.js"></script>
+		<script src="https://unpkg.com/three@0.142.0/build/three.js"></script>
+    <script src="./dat.gui.min.js"></script>
+    <script src="https://unpkg.com/three@0.142.0/examples/js/controls/OrbitControls.js"></script>
 		<script src="https://threejs.org/examples/js/Detector.js"></script>
-		<script src="https://threejs.org/examples/js/libs/dat.gui.min.js"></script>
-		<script src="https://threejs.org/examples/js/controls/OrbitControls.js"></script>
 		<script src="./gutcp.js"></script>
 
 		<script>
@@ -155,7 +155,7 @@
 			}
 
 			function getCameraConstant( camera ) {
-				return window.innerHeight / ( Math.tan( THREE.Math.DEG2RAD * 0.5 * camera.fov ) / camera.zoom );
+				return window.innerHeight / ( Math.tan( THREE.MathUtils.DEG2RAD * 0.5 * camera.fov ) / camera.zoom );
 			}
 
 			function initGUI() {

--- a/GUTCP_Spacetime.html
+++ b/GUTCP_Spacetime.html
@@ -20,12 +20,12 @@
             >Dr Randell L Mills</a> - FDTD Simulation by : <a href="mailto:vacamiguel@gmail.com">J Miguel Vaca</a> 
         </div>
 
-		<script src="https://threejs.org/build/three.js"></script>
+		<script src="https://unpkg.com/three@0.142.0/build/three.js"></script>
+    <script src="./dat.gui.min.js"></script>
+    <script src="https://unpkg.com/three@0.142.0/examples/js/controls/OrbitControls.js"></script>
 		<script src="https://mrdoob.github.io/three.js/examples/js/WebGL.js"></script>
 		<!--script src="https://threejs.org/examples/js/Detector.js"></script-->
 		<script src="https://threejs.org/examples/js/libs/stats.min.js"></script>
-		<script src="https://threejs.org/examples/js/libs/dat.gui.min.js"></script>
-		<script src="https://threejs.org/examples/js/controls/OrbitControls.js"></script>
 		<script src="https://threejs.org/examples/jsm/misc/GPUComputationRenderer.js"></script>
 		<script src="gutcp.js"></script>
 
@@ -580,7 +580,7 @@
 
 			function getCameraConstant( camera ) {
 
-				return window.innerHeight / ( Math.tan( THREE.Math.DEG2RAD * 0.5 * camera.fov ) / camera.zoom );
+				return window.innerHeight / ( Math.tan( THREE.MathUtils.DEG2RAD * 0.5 * camera.fov ) / camera.zoom );
 			}
 
 			function animate() {

--- a/GUTCP_Spacetime_old.html
+++ b/GUTCP_Spacetime_old.html
@@ -16,10 +16,10 @@
             <br>Physics by : <a href="mailto:rmills@brilliantlightpower.com">Dr Randell L Mills</a> - Visualisation by : <a href="mailto:vacamiguel@gmail.com">J Miguel Vaca</a> 
         </div>
 
-		<script src="https://threejs.org/build/three.js"></script>
-		<script src="https://threejs.org/examples/js/libs/dat.gui.min.js"></script>
-		<script src="https://threejs.org/examples/js/controls/OrbitControls.js"></script>
-		<script src="./gutcp.js"></script>
+		<script src="https://unpkg.com/three@0.142.0/build/three.js"></script>
+    <script src="./dat.gui.min.js"></script>
+    <script src="https://unpkg.com/three@0.142.0/examples/js/controls/OrbitControls.js"></script>
+    <script src="./gutcp.js"></script>
 
 		<script>
 
@@ -151,7 +151,7 @@
 			}
 
 			function getCameraConstant( camera ) {
-				return window.innerHeight / ( Math.tan( THREE.Math.DEG2RAD * 0.5 * camera.fov ) / camera.zoom );
+				return window.innerHeight / ( Math.tan( THREE.MathUtils.DEG2RAD * 0.5 * camera.fov ) / camera.zoom );
 			}
 
 			function initGUI() {

--- a/SphericalHarmonics.html
+++ b/SphericalHarmonics.html
@@ -120,7 +120,7 @@
 			}
 
 			function getCameraConstant( camera ) {
-				return window.innerHeight / ( Math.tan( THREE.Math.DEG2RAD * 0.5 * camera.fov ) / camera.zoom );
+				return window.innerHeight / ( Math.tan( THREE.MathUtils.DEG2RAD * 0.5 * camera.fov ) / camera.zoom );
 			}
 
 			function initGUI() {


### PR DESCRIPTION
The HTML files were pointing to the latest dynamic version of three.js and three addons, some of which have moved/deprecated etc. This PR just points to unpkg versions at what I estimate is about the correct versions. The examples linked to from index.html now all work. Some of the other examples don't. I think they may need some refactoring etc.